### PR TITLE
feature/add use union types option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { Options } from "openapi-typescript-codegen";
 export type CLIOptions = {
   output?: string;
   client?: Options["httpClient"];
-} & Pick<Options, 'exportSchemas' | 'postfix' | 'request' | 'indent' | 'input'>;
+} & Pick<Options, 'exportSchemas' | 'postfix' | 'request' | 'indent' | 'input' | 'useUnionTypes'>;
 
 const program = new Command();
 
@@ -25,6 +25,7 @@ program
     "HTTP client to generate [fetch, xhr, node, axios, angular]",
     "fetch"
   )
+  .option("--useUnionTypes", "Use union types", false)
   .option("--exportSchemas <value>", "Write schemas to disk", false)
   .option("--indent <value>", "Indentation options [4, 2, tabs]", "4")
   .option("--postfix <value>", "Service name postfix", "Service")


### PR DESCRIPTION
- QueryKeys: default query keys to include any params (#9)
- query: fix optional params (#11)
- chore: upgrade dependencies (#12)
- chore: release v0.3.1
- fix: Optional parameters in mutation. Related to #11 (#13)
- chore: release v0.3.2
- patch(deps): relax dependencies so consumers can specify versions (#14)
- chore: update pnpm-lock.yaml (#15)
- chore: upgrade dependencies in example
- chore: release v0.3.3
- feature(cli): add useUnionTypes option
